### PR TITLE
Install templates and static files too.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+recursive-include dryrub/static *.css *.js *.png *.jpeg *.jpg *.gif
+recursive-include dryrub/templates *.html

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
     author_email='apendleton@sunlightfoundation.com',
     url='http://github.com/sunlightlabs/dryrub/',
     packages=find_packages(),
+    include_package_data=True, # Include files from MANIFEST.in
     license='BSD License',
     platforms=["any"],
     py_modules=["dryrub"],


### PR DESCRIPTION
Tim ran into this when deploying FARA yesterday. When he installed dryrub via `pip -r requirements.txt` it didn't install the templates. I know some people advocate for having downstream users copy the templates into their own project but if they're installed along with the python code the downstream users can still copy the templates into their own templates directory so long as they order their template paths correctly in settings.
